### PR TITLE
👷 Setup Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  # Enable version updates for git submodules
+  - package-ecosystem: "gitsubmodule"
+    # Look for `.gitmodules` in the `root` directory
+    directory:         "/"
+    # Check the submodules for updates every month
+    schedule:
+      interval: "weekly"
+      day:      "monday"
+      time:     "06:00"
+    assignees:
+      - "burgholzer"
+
+  # Enable version updates for GitHub Actions
+  - package-ecosystem: "github-actions"
+    # Look for `*.yml` files in the `.github/workflows` directory
+    directory:         "/"
+    # Check for updates to GitHub Actions every week
+    schedule:
+      interval: "weekly"
+      day:      "monday"
+      time:     "06:00"
+    assignees:
+      - "burgholzer"


### PR DESCRIPTION
This PR sets up dependabot in order to manage submodule and GitHub Actions updates.