### PR TITLE
♻️ use `#pragma once`

### DIFF
--- a/include/Definitions.hpp
+++ b/include/Definitions.hpp
@@ -1,5 +1,4 @@
-#ifndef ZX_INCLUDE_DEFINITIONS_HPP_
-#define ZX_INCLUDE_DEFINITIONS_HPP_
+#pragma once
 
 #include <stdexcept>
 
@@ -32,4 +31,3 @@ namespace zx {
         }
     };
 } // namespace zx
-#endif /* JKQZX_INCLUDE_DEFINITIONS_HPP_ */

--- a/include/Expression.hpp
+++ b/include/Expression.hpp
@@ -1,5 +1,4 @@
-#ifndef ZX_INCLUDE_EXPRESSION_HPP_
-#define ZX_INCLUDE_EXPRESSION_HPP_
+#pragma once
 
 #include "Definitions.hpp"
 #include "Rational.hpp"
@@ -160,4 +159,3 @@ inline std::ostream& operator<<(std::ostream& os, const zx::Expression& rhs) {
     os << rhs.get_constant();
     return os;
 }
-#endif /* ZX_INCLUDE_EXPRESSION_HPP_ */

--- a/include/Rational.hpp
+++ b/include/Rational.hpp
@@ -1,5 +1,4 @@
-#ifndef ZX_INCLUDE_RATIONAL_HPP_
-#define ZX_INCLUDE_RATIONAL_HPP_
+#pragma once
 
 #include <gmpxx.h>
 #include <iostream>
@@ -182,5 +181,3 @@ namespace zx {
     }
 
 } // namespace zx
-
-#endif /* JKQZX_INCLUDE_RATIONAL_HPP_ */

--- a/include/Rules.hpp
+++ b/include/Rules.hpp
@@ -1,5 +1,4 @@
-#ifndef ZX_INCLUDE_RULES_HPP_
-#define ZX_INCLUDE_RULES_HPP_
+#pragma once
 
 #include "ZXDiagram.hpp"
 
@@ -30,5 +29,3 @@ namespace zx {
 
     bool check_and_fuse_gadget(ZXDiagram& diag, Vertex v);
 } // namespace zx
-
-#endif /* JKQZX_INCLUDE_RULES_HPP_ */

--- a/include/Simplify.hpp
+++ b/include/Simplify.hpp
@@ -1,5 +1,4 @@
-#ifndef ZX_INCLUDE_SIMPLIFY_HPP_
-#define ZX_INCLUDE_SIMPLIFY_HPP_
+#pragma once
 
 #include "Rules.hpp"
 #include "ZXDiagram.hpp"
@@ -36,5 +35,3 @@ namespace zx {
     int32_t full_reduce(ZXDiagram& diag);
 
 } // namespace zx
-
-#endif /* JKQZX_INCLUDE_SIMPLIFY_HPP_ */

--- a/include/Utils.hpp
+++ b/include/Utils.hpp
@@ -1,5 +1,4 @@
-#ifndef ZX_INCLUDE_UTILS_HPP_
-#define ZX_INCLUDE_UTILS_HPP_
+#pragma once
 
 #include "Definitions.hpp"
 #include "Expression.hpp"
@@ -129,5 +128,3 @@ namespace zx {
         std::vector<std::optional<VertexData>>& vertices;
     };
 } // namespace zx
-
-#endif /* JKQZX_INCLUDE_UTILS_HPP_ */

--- a/include/ZXDiagram.hpp
+++ b/include/ZXDiagram.hpp
@@ -1,5 +1,4 @@
-#ifndef ZX_INCLUDE_GRAPH_HPP_
-#define ZX_INCLUDE_GRAPH_HPP_
+#pragma once
 
 #include "Definitions.hpp"
 #include "Expression.hpp"
@@ -150,4 +149,3 @@ namespace zx {
         //                       std::vector<Vertex> &qubit_vertices);
     };
 } // namespace zx
-#endif /* ZX_INCLUDE_GRAPH_HPP_ */


### PR DESCRIPTION
Use the more convenient `#pragma once` instead of old-school header guards.