### PR TITLE
✨Early termination of simplification

### DIFF
--- a/include/Simplify.hpp
+++ b/include/Simplify.hpp
@@ -4,12 +4,12 @@
 #include "ZXDiagram.hpp"
 
 namespace zx {
-    using VertexCheckFun         = decltype(checkIdSimp);
-    using VertexRuleFun          = decltype(removeId);
-    using EdgeCheckFun           = decltype(checkSpiderFusion);
-    using EdgeRuleFun            = decltype(fuseSpiders);
-    constexpr auto defaultIsDone = []() { return false; };
-    using TerminationFun         = decltype(defaultIsDone);
+    using VertexCheckFun                          = decltype(checkIdSimp);
+    using VertexRuleFun                           = decltype(removeId);
+    using EdgeCheckFun                            = decltype(checkSpiderFusion);
+    using EdgeRuleFun                             = decltype(fuseSpiders);
+    const std::function<bool(void)> defaultIsDone = []() { return false; };
+    using TerminationFun                          = decltype(defaultIsDone);
 
     std::size_t simplifyVertices(ZXDiagram& diag, VertexCheckFun check,
                                  VertexRuleFun rule, const TerminationFun& isDone = defaultIsDone);

--- a/include/Simplify.hpp
+++ b/include/Simplify.hpp
@@ -4,36 +4,38 @@
 #include "ZXDiagram.hpp"
 
 namespace zx {
-    using VertexCheckFun = decltype(checkIdSimp);
-    using VertexRuleFun  = decltype(removeId);
-    using EdgeCheckFun   = decltype(checkSpiderFusion);
-    using EdgeRuleFun    = decltype(fuseSpiders);
+    using VertexCheckFun         = decltype(checkIdSimp);
+    using VertexRuleFun          = decltype(removeId);
+    using EdgeCheckFun           = decltype(checkSpiderFusion);
+    using EdgeRuleFun            = decltype(fuseSpiders);
+    constexpr auto defaultIsDone = []() { return false; };
+    using TerminationFun         = decltype(defaultIsDone);
 
     std::size_t simplifyVertices(ZXDiagram& diag, VertexCheckFun check,
-                                 VertexRuleFun rule);
+                                 VertexRuleFun rule, const TerminationFun& isDone = defaultIsDone);
 
     std::size_t simplifyEdges(ZXDiagram& diag, EdgeCheckFun check,
-                              EdgeRuleFun rule);
+                              EdgeRuleFun rule, const TerminationFun& isDone = defaultIsDone);
 
-    std::size_t gadgetSimp(ZXDiagram& diag);
+    std::size_t gadgetSimp(ZXDiagram& diag, const TerminationFun& isDone = defaultIsDone);
 
-    std::size_t idSimp(ZXDiagram& diag);
+    std::size_t idSimp(ZXDiagram& diag, const TerminationFun& isDone = defaultIsDone);
 
-    std::size_t spiderSimp(ZXDiagram& diag);
+    std::size_t spiderSimp(ZXDiagram& diag, const TerminationFun& isDone = defaultIsDone);
 
-    std::size_t localCompSimp(ZXDiagram& diag);
+    std::size_t localCompSimp(ZXDiagram& diag, const TerminationFun& isDone = defaultIsDone);
 
-    std::size_t pivotPauliSimp(ZXDiagram& diag);
+    std::size_t pivotPauliSimp(ZXDiagram& diag, const TerminationFun& isDone = defaultIsDone);
 
-    std::size_t pivotSimp(ZXDiagram& diag);
+    std::size_t pivotSimp(ZXDiagram& diag, const TerminationFun& isDone = defaultIsDone);
 
-    std::size_t interiorCliffordSimp(ZXDiagram& diag);
+    std::size_t interiorCliffordSimp(ZXDiagram& diag, const TerminationFun& isDone = defaultIsDone);
 
-    std::size_t cliffordSimp(ZXDiagram& diag);
+    std::size_t cliffordSimp(ZXDiagram& diag, const TerminationFun& isDone = defaultIsDone);
 
-    std::size_t pivotgadgetSimp(ZXDiagram& diag);
+    std::size_t pivotgadgetSimp(ZXDiagram& diag, const TerminationFun& isDone = defaultIsDone);
 
-    std::size_t fullReduce(ZXDiagram& diag);
-    std::size_t fullReduceApproximate(ZXDiagram& diag, fp tolerance);
+    std::size_t fullReduce(ZXDiagram& diag, const TerminationFun& isDone = defaultIsDone);
+    std::size_t fullReduceApproximate(ZXDiagram& diag, fp tolerance, const TerminationFun& isDone = defaultIsDone);
 
 } // namespace zx


### PR DESCRIPTION
This PR adds the means to optionally specify a termination function for the simplification procedure.
This allows for early termination and eliminates waiting on a result when it is no longer needed.

@pehamTom: are there any more places, where incorporating such a check would make sense?