### PR TITLE
🔧 Update dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,11 +6,11 @@ updates:
     directory:         "/"
     # Check the submodules for updates every month
     schedule:
-      interval: "weekly"
-      day:      "monday"
+      interval: "monthly"
       time:     "06:00"
+      timezone: "Europe/Vienna"
     assignees:
-      - "burgholzer"
+      - "pehamTom"
 
   # Enable version updates for GitHub Actions
   - package-ecosystem: "github-actions"
@@ -21,5 +21,6 @@ updates:
       interval: "weekly"
       day:      "monday"
       time:     "06:00"
+      timezone: "Europe/Vienna"
     assignees:
-      - "burgholzer"
+      - "pehamTom"


### PR DESCRIPTION
This PR updates the dependabot configuration of this project.

 - the frequency of submodule updates is reduced to monthly in order to reduce the noise generated by PRs in all of our repositories by changes that are not really relevant to the performance of our core libraries
 - @pehamTom is now assigned to the respective PRs by default
 - timezones are added to the configuration