### PR TITLE
Adjacency matrix

### DIFF
--- a/include/Definitions.hpp
+++ b/include/Definitions.hpp
@@ -36,4 +36,7 @@ namespace zx {
             return msg.c_str();
         }
     };
+
+    using gf2Mat = std::vector<std::vector<bool>>;
+    using gf2Vec = std::vector<bool>;
 } // namespace zx

--- a/include/Utils.hpp
+++ b/include/Utils.hpp
@@ -37,23 +37,23 @@ namespace zx {
     class Vertices {
     public:
         explicit Vertices(
-                std::vector<std::optional<VertexData>>& vertices):
+                const std::vector<std::optional<VertexData>>& vertices):
             vertices(vertices){};
 
         class VertexIterator {
         public:
             using iterator_category = std::forward_iterator_tag;
             using difference_type   = std::int32_t;
-            using value_type        = std::pair<Vertex, VertexData&>;
+            using value_type        = std::pair<Vertex, const VertexData&>;
             using pointer           = value_type*;
             using reference         = value_type&;
 
-            explicit VertexIterator(std::vector<std::optional<VertexData>>& vertices):
+            explicit VertexIterator(const std::vector<std::optional<VertexData>>& vertices):
                 currentPos(vertices.begin()), vertices(vertices) {
                 nextValidVertex();
             }
-            VertexIterator(std::vector<std::optional<VertexData>>& vertices,
-                           Vertex                                  v);
+            VertexIterator(const std::vector<std::optional<VertexData>>& vertices,
+                           Vertex                                        v);
 
             value_type operator*() const { return {v, currentPos->value()}; }
             // pointer operator->() { return ptr; }
@@ -70,26 +70,26 @@ namespace zx {
                                    const VertexIterator& b);
 
         private:
-            Vertex                                           v = 0;
-            std::vector<std::optional<VertexData>>::iterator currentPos;
-            std::vector<std::optional<VertexData>>&          vertices;
+            Vertex                                                 v = 0;
+            std::vector<std::optional<VertexData>>::const_iterator currentPos;
+            const std::vector<std::optional<VertexData>>&          vertices;
 
             void nextValidVertex();
         };
 
         using iterator = VertexIterator;
 
-        iterator begin() { return VertexIterator(vertices); }
-        iterator end() { return {vertices, vertices.size()}; }
+        const iterator begin() { return VertexIterator(vertices); }
+        const iterator end() { return {vertices, vertices.size()}; }
 
     private:
-        std::vector<std::optional<VertexData>>& vertices;
+        const std::vector<std::optional<VertexData>>& vertices;
     };
 
     class Edges {
     public:
-        Edges(std::vector<std::vector<Edge>>&         edges,
-              std::vector<std::optional<VertexData>>& vertices):
+        Edges(const std::vector<std::vector<Edge>>&         edges,
+              const std::vector<std::optional<VertexData>>& vertices):
             edges(edges),
             vertices(vertices){};
 
@@ -101,11 +101,11 @@ namespace zx {
             using pointer           = value_type*;
             using reference         = value_type&;
 
-            EdgeIterator(std::vector<std::vector<Edge>>&         edges,
-                         std::vector<std::optional<VertexData>>& vertices);
+            EdgeIterator(const std::vector<std::vector<Edge>>&         edges,
+                         const std::vector<std::optional<VertexData>>& vertices);
 
-            EdgeIterator(std::vector<std::vector<Edge>>&         edges,
-                         std::vector<std::optional<VertexData>>& vertices, Vertex v);
+            EdgeIterator(const std::vector<std::vector<Edge>>&         edges,
+                         const std::vector<std::optional<VertexData>>& vertices, Vertex v);
 
             value_type operator*() const { return {v, currentPos->to}; }
             // pointer operator->() { return ptr; }
@@ -120,23 +120,23 @@ namespace zx {
             friend bool operator!=(const EdgeIterator& a, const EdgeIterator& b);
 
         private:
-            Vertex                                   v;
-            std::vector<Edge>::iterator              currentPos;
-            std::vector<std::vector<Edge>>::iterator edgesPos;
-            std::vector<std::vector<Edge>>&          edges;
-            std::vector<std::optional<VertexData>>&  vertices;
+            Vertex                                         v;
+            std::vector<Edge>::const_iterator              currentPos;
+            std::vector<std::vector<Edge>>::const_iterator edgesPos;
+            const std::vector<std::vector<Edge>>&          edges;
+            const std::vector<std::optional<VertexData>>&  vertices;
 
             void checkNextVertex();
         };
 
         using iterator = EdgeIterator;
 
-        iterator begin() { return {edges, vertices}; }
-        iterator end() { return {edges, vertices, edges.size()}; }
+        const iterator begin() { return {edges, vertices}; }
+        const iterator end() { return {edges, vertices, edges.size()}; }
 
     private:
-        std::vector<std::vector<Edge>>&         edges;
-        std::vector<std::optional<VertexData>>& vertices;
+        const std::vector<std::vector<Edge>>&         edges;
+        const std::vector<std::optional<VertexData>>& vertices;
     };
 
     bool isPauli(const PiExpression& expr);

--- a/include/ZXDiagram.hpp
+++ b/include/ZXDiagram.hpp
@@ -123,7 +123,8 @@ namespace zx {
         [[nodiscard]] bool globalPhaseIsZero() const {
             return globalPhase.isZero();
         }
-        gf2Mat getAdjMat() const;
+        gf2Mat              getAdjMat() const;
+        std::vector<Vertex> getConnectedSet(const std::vector<Vertex>& s) const;
 
     private:
         std::vector<std::vector<Edge>>         edges;

--- a/include/ZXDiagram.hpp
+++ b/include/ZXDiagram.hpp
@@ -124,7 +124,7 @@ namespace zx {
             return globalPhase.isZero();
         }
         gf2Mat              getAdjMat() const;
-        std::vector<Vertex> getConnectedSet(const std::vector<Vertex>& s) const;
+        std::vector<Vertex> getConnectedSet(const std::vector<Vertex>& s, const std::vector<Vertex>& exclude = {}) const;
         static bool         isIn(const Vertex& v, const std::vector<Vertex>& vertices);
 
     private:

--- a/include/ZXDiagram.hpp
+++ b/include/ZXDiagram.hpp
@@ -125,6 +125,7 @@ namespace zx {
         }
         gf2Mat              getAdjMat() const;
         std::vector<Vertex> getConnectedSet(const std::vector<Vertex>& s) const;
+        static bool         isIn(const Vertex& v, const std::vector<Vertex>& vertices);
 
     private:
         std::vector<std::vector<Edge>>         edges;

--- a/include/ZXDiagram.hpp
+++ b/include/ZXDiagram.hpp
@@ -61,8 +61,8 @@ namespace zx {
             return vertices[v];
         }
 
-        [[nodiscard]] std::vector<std::pair<Vertex, VertexData&>> getVertices();
-        [[nodiscard]] std::vector<std::pair<Vertex, Vertex>>      getEdges();
+        [[nodiscard]] std::vector<std::pair<Vertex, const VertexData&>> getVertices() const;
+        [[nodiscard]] std::vector<std::pair<Vertex, Vertex>>            getEdges() const;
 
         [[nodiscard]] const std::vector<Vertex>& getInputs() const {
             return inputs;
@@ -123,6 +123,7 @@ namespace zx {
         [[nodiscard]] bool globalPhaseIsZero() const {
             return globalPhase.isZero();
         }
+        gf2Mat getAdjMat() const;
 
     private:
         std::vector<std::vector<Edge>>         edges;

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -4,7 +4,7 @@
 
 namespace zx {
     Vertices::VertexIterator::VertexIterator(
-            std::vector<std::optional<VertexData>>& vertices, const Vertex v):
+            const std::vector<std::optional<VertexData>>& vertices, const Vertex v):
         v(v),
         currentPos(vertices.begin()), vertices(vertices) {
         if (v >= vertices.size()) {
@@ -49,8 +49,8 @@ namespace zx {
     }
 
     Edges::EdgeIterator::EdgeIterator(
-            std::vector<std::vector<Edge>>&         edges,
-            std::vector<std::optional<VertexData>>& vertices):
+            const std::vector<std::vector<Edge>>&         edges,
+            const std::vector<std::optional<VertexData>>& vertices):
         v(0),
         currentPos(edges[0].begin()), edgesPos(edges.begin()), edges(edges), vertices(vertices) {
         if (!vertices.empty()) {
@@ -68,8 +68,8 @@ namespace zx {
     }
 
     Edges::EdgeIterator::EdgeIterator(
-            std::vector<std::vector<Edge>>&         edges,
-            std::vector<std::optional<VertexData>>& vertices, const Vertex v):
+            const std::vector<std::vector<Edge>>&         edges,
+            const std::vector<std::optional<VertexData>>& vertices, const Vertex v):
         v(v),
         edges(edges), vertices(vertices) {
         if (v >= edges.size()) {

--- a/src/ZXDiagram.cpp
+++ b/src/ZXDiagram.cpp
@@ -162,13 +162,14 @@ namespace zx {
         return edge;
     }
 
-    [[nodiscard]] std::vector<std::pair<Vertex, VertexData&>>
-    ZXDiagram::getVertices() {
+    [[nodiscard]] std::vector<std::pair<Vertex, const VertexData&>>
+    ZXDiagram::getVertices() const {
         Vertices verts(vertices);
+
         return {verts.begin(), verts.end()};
     }
 
-    [[nodiscard]] std::vector<std::pair<Vertex, Vertex>> ZXDiagram::getEdges() {
+    [[nodiscard]] std::vector<std::pair<Vertex, Vertex>> ZXDiagram::getEdges() const {
         Edges es(edges, vertices);
         return {es.begin(), es.end()};
     }
@@ -369,4 +370,15 @@ namespace zx {
         globalPhase += phase;
     }
 
+    gf2Mat ZXDiagram::getAdjMat() const {
+        gf2Mat adjMat{nvertices, gf2Vec(nvertices, false)};
+        for (const auto& [from, to]: getEdges()) {
+            adjMat[from][to] = true;
+            adjMat[to][from] = true;
+        }
+        for (std::size_t i = 0; i < adjMat.size(); ++i) {
+            adjMat[i][i] = true;
+        }
+        return adjMat;
+    }
 } // namespace zx

--- a/src/ZXDiagram.cpp
+++ b/src/ZXDiagram.cpp
@@ -398,4 +398,8 @@ namespace zx {
         }
         return connected;
     }
+
+    bool ZXDiagram::isIn(const Vertex& v, const std::vector<Vertex>& vertices) {
+        return std::find(vertices.begin(), vertices.end(), v) != vertices.end();
+    }
 } // namespace zx

--- a/src/ZXDiagram.cpp
+++ b/src/ZXDiagram.cpp
@@ -381,4 +381,21 @@ namespace zx {
         }
         return adjMat;
     }
+
+    std::vector<Vertex> ZXDiagram::getConnectedSet(const std::vector<Vertex>& s) const {
+        std::vector<Vertex> connected;
+        for (const auto v: s) {
+            for (const auto& [to, _]: edges[v]) {
+                const auto& p = std::lower_bound(connected.begin(), connected.end(), to);
+                if (p == connected.end()) {
+                    connected.emplace_back(to);
+                    continue;
+                }
+                if (*p != to) {
+                    connected.insert(p, to);
+                }
+            }
+        }
+        return connected;
+    }
 } // namespace zx

--- a/src/ZXDiagram.cpp
+++ b/src/ZXDiagram.cpp
@@ -382,10 +382,13 @@ namespace zx {
         return adjMat;
     }
 
-    std::vector<Vertex> ZXDiagram::getConnectedSet(const std::vector<Vertex>& s) const {
+    std::vector<Vertex> ZXDiagram::getConnectedSet(const std::vector<Vertex>& s, const std::vector<Vertex>& exclude) const {
         std::vector<Vertex> connected;
         for (const auto v: s) {
             for (const auto& [to, _]: edges[v]) {
+                if (isIn(to, exclude))
+                    continue;
+
                 const auto& p = std::lower_bound(connected.begin(), connected.end(), to);
                 if (p == connected.end()) {
                     connected.emplace_back(to);

--- a/test/test_expression.cpp
+++ b/test/test_expression.cpp
@@ -193,6 +193,6 @@ TEST_F(ExpressionTest, Instantiation) {
     EXPECT_PRED_FORMAT2(testing::FloatLE, e.evaluate(assignment), 5.0);
 
     e += z;
-
-    EXPECT_THROW(e.evaluate(assignment), sym::SymbolicException);
+    [[maybe_unused]] double h;
+    EXPECT_THROW(h = e.evaluate(assignment), sym::SymbolicException);
 }

--- a/test/test_zx.cpp
+++ b/test/test_zx.cpp
@@ -217,3 +217,36 @@ TEST_F(ZXDiagramTest, RemoveScalarSubDiagram) {
     EXPECT_TRUE(idWithScal.isDeleted(v));
     EXPECT_TRUE(idWithScal.isDeleted(w));
 }
+
+TEST_F(ZXDiagramTest, AdjMat) {
+    zx::ZXDiagram diag(3);
+
+    const auto& adj = diag.getAdjMat();
+
+    for (const auto& [v, _]: diag.getVertices()) {
+        for (const auto& [w, _]: diag.getVertices()) {
+            if (diag.connected(v, w) || v == w) {
+                EXPECT_TRUE(adj[v][w]);
+                EXPECT_TRUE(adj[w][v]);
+            } else {
+                EXPECT_FALSE(adj[v][w]);
+                EXPECT_FALSE(adj[w][v]);
+            }
+        }
+    }
+}
+
+TEST_F(ZXDiagramTest, ConnectedSet) {
+    zx::ZXDiagram diag(3);
+    auto          connected = diag.getConnectedSet(diag.getInputs());
+
+    for (const auto& v: connected) {
+        EXPECT_TRUE(diag.isIn(v, diag.getOutputs()));
+    }
+
+    connected = diag.getConnectedSet(diag.getInputs(), {4});
+
+    EXPECT_TRUE(diag.isIn(3, connected));
+    EXPECT_FALSE(diag.isIn(4, connected));
+    EXPECT_TRUE(diag.isIn(5, connected));
+}


### PR DESCRIPTION
This PR introduces the ability to construct the adjacency matrix of a ZX-diagram.

Furthermore the `getEdges` and `getVertices` methods of the `ZXDiagram` class have been made `const`.