### PR TITLE
🚨 Introduce pre-commit for consistent styling

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,82 +1,82 @@
 # Generated from CLion C/C++ Code Style settings
-BasedOnStyle:                              LLVM
-AccessModifierOffset:                      -4
-AlignAfterOpenBracket:                     Align
-AlignConsecutiveAssignments:               Consecutive
-AlignConsecutiveDeclarations:              Consecutive
-AlignEscapedNewlines:                      Left
-AlignOperands:                             AlignAfterOperator
-AlignTrailingComments:                     true
-AllowAllArgumentsOnNextLine:               true
+BasedOnStyle: LLVM
+AccessModifierOffset: -4
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: Consecutive
+AlignConsecutiveDeclarations: Consecutive
+AlignEscapedNewlines: Left
+AlignOperands: AlignAfterOperator
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
 AllowAllConstructorInitializersOnNextLine: true
 AllowAllParametersOfDeclarationOnNextLine: true
-AllowShortBlocksOnASingleLine:             Empty
-AllowShortCaseLabelsOnASingleLine:         true
-AllowShortEnumsOnASingleLine:              true
-AllowShortFunctionsOnASingleLine:          Inline
-AllowShortIfStatementsOnASingleLine:       WithoutElse
-AllowShortLambdasOnASingleLine:            All
-AllowShortLoopsOnASingleLine:              true
-AlwaysBreakAfterReturnType:                None
-AlwaysBreakTemplateDeclarations:           Yes
-BreakBeforeBraces:                         Custom
+AllowShortBlocksOnASingleLine: Empty
+AllowShortCaseLabelsOnASingleLine: true
+AllowShortEnumsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortIfStatementsOnASingleLine: WithoutElse
+AllowShortLambdasOnASingleLine: All
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterReturnType: None
+AlwaysBreakTemplateDeclarations: Yes
+BreakBeforeBraces: Custom
 BraceWrapping:
-  AfterCaseLabel:        false
-  AfterClass:            false
+  AfterCaseLabel: false
+  AfterClass: false
   AfterControlStatement: Never
-  AfterEnum:             false
-  AfterFunction:         false
-  AfterNamespace:        false
-  AfterUnion:            false
-  BeforeCatch:           false
-  BeforeElse:            false
-  IndentBraces:          false
-  SplitEmptyFunction:    false
-  SplitEmptyRecord:      false
-BreakBeforeBinaryOperators:                None
-BreakBeforeTernaryOperators:               false
-BreakConstructorInitializers:              AfterColon
-BreakInheritanceList:                      AfterColon
-ColumnLimit:                               0
-CompactNamespaces:                         false
-ContinuationIndentWidth:                   8
-Cpp11BracedListStyle:                      true
-DeriveLineEnding:                          true
-EmptyLineBeforeAccessModifier:             LogicalBlock
-IncludeBlocks:                             Regroup
-IndentCaseBlocks:                          false
-IndentCaseLabels:                          true
-IndentPPDirectives:                        BeforeHash
-IndentWidth:                               4
-KeepEmptyLinesAtTheStartOfBlocks:          false
-Language:                                  Cpp
-MaxEmptyLinesToKeep:                       1
-NamespaceIndentation:                      All
-ObjCSpaceAfterProperty:                    false
-ObjCSpaceBeforeProtocolList:               true
-PointerAlignment:                          Left
-ReflowComments:                            false
-SortIncludes:                              CaseInsensitive
-SpaceAfterCStyleCast:                      false
-SpaceAfterLogicalNot:                      false
-SpaceAfterTemplateKeyword:                 false
-SpaceBeforeAssignmentOperators:            true
-SpaceBeforeCaseColon:                      false
-SpaceBeforeCpp11BracedList:                false
-SpaceBeforeCtorInitializerColon:           false
-SpaceBeforeInheritanceColon:               false
-SpaceBeforeParens:                         ControlStatements
-SpaceBeforeRangeBasedForLoopColon:         false
-SpaceBeforeSquareBrackets:                 false
-SpaceInEmptyBlock:                         false
-SpaceInEmptyParentheses:                   false
-SpacesBeforeTrailingComments:              1
-SpacesInAngles:                            false
-SpacesInConditionalStatement:              false
-SpacesInCStyleCastParentheses:             false
-SpacesInContainerLiterals:                 false
-SpacesInParentheses:                       false
-SpacesInSquareBrackets:                    false
-Standard:                                  c++17
-TabWidth:                                  4
-UseTab:                                    Never
+  AfterEnum: false
+  AfterFunction: false
+  AfterNamespace: false
+  AfterUnion: false
+  BeforeCatch: false
+  BeforeElse: false
+  IndentBraces: false
+  SplitEmptyFunction: false
+  SplitEmptyRecord: false
+BreakBeforeBinaryOperators: None
+BreakBeforeTernaryOperators: false
+BreakConstructorInitializers: AfterColon
+BreakInheritanceList: AfterColon
+ColumnLimit: 0
+CompactNamespaces: false
+ContinuationIndentWidth: 8
+Cpp11BracedListStyle: true
+DeriveLineEnding: true
+EmptyLineBeforeAccessModifier: LogicalBlock
+IncludeBlocks: Regroup
+IndentCaseBlocks: false
+IndentCaseLabels: true
+IndentPPDirectives: BeforeHash
+IndentWidth: 4
+KeepEmptyLinesAtTheStartOfBlocks: false
+Language: Cpp
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: All
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PointerAlignment: Left
+ReflowComments: false
+SortIncludes: CaseInsensitive
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: false
+SpaceBeforeInheritanceColon: false
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: false
+SpaceBeforeSquareBrackets: false
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles: false
+SpacesInConditionalStatement: false
+SpacesInCStyleCastParentheses: false
+SpacesInContainerLiterals: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard: c++17
+TabWidth: 4
+UseTab: Never

--- a/.cmake-format.yaml
+++ b/.cmake-format.yaml
@@ -1,0 +1,4 @@
+format:
+  line_width: 100
+  keyword_case: "upper"
+  autosort: true

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -3,7 +3,7 @@ ignore:
   - "test/*.cpp"
 
 coverage:
-  range:     60..90
+  range: 60..90
   precision: 1
   status:
     project:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,11 +3,11 @@ updates:
   # Enable version updates for git submodules
   - package-ecosystem: "gitsubmodule"
     # Look for `.gitmodules` in the `root` directory
-    directory:         "/"
+    directory: "/"
     # Check the submodules for updates every month
     schedule:
       interval: "monthly"
-      time:     "06:00"
+      time: "06:00"
       timezone: "Europe/Vienna"
     assignees:
       - "pehamTom"
@@ -15,12 +15,12 @@ updates:
   # Enable version updates for GitHub Actions
   - package-ecosystem: "github-actions"
     # Look for `*.yml` files in the `.github/workflows` directory
-    directory:         "/"
+    directory: "/"
     # Check for updates to GitHub Actions every week
     schedule:
       interval: "weekly"
-      day:      "monday"
-      time:     "06:00"
+      day: "monday"
+      time: "06:00"
       timezone: "Europe/Vienna"
     assignees:
       - "pehamTom"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,17 +16,6 @@ defaults:
     shell: bash
 
 jobs:
-  codestyle:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          submodules: recursive
-      - uses: DoozyX/clang-format-lint-action@v0.15
-        with:
-          source: "include src test"
-          clangFormatVersion: 14
-
   build:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
   workflow_dispatch:
 
 env:
@@ -24,7 +24,7 @@ jobs:
           submodules: recursive
       - uses: DoozyX/clang-format-lint-action@v0.15
         with:
-          source:             'include src test'
+          source: "include src test"
           clangFormatVersion: 14
 
   build:
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
       - uses: actions/checkout@v3
@@ -40,23 +40,23 @@ jobs:
           submodules: recursive
 
       - name: Configure CMake
-        run:  |
-              if [ "$RUNNER_OS" == "Windows" ]; then
-                cmake -S "${{github.workspace}}" -B "${{github.workspace}}/build" -DCMAKE_BUILD_TYPE=$BUILD_TYPE -T "ClangCl"
-              else
-                cmake -S "${{github.workspace}}" -B "${{github.workspace}}/build" -DCMAKE_BUILD_TYPE=$BUILD_TYPE
-              fi  
+        run: |
+          if [ "$RUNNER_OS" == "Windows" ]; then
+            cmake -S "${{github.workspace}}" -B "${{github.workspace}}/build" -DCMAKE_BUILD_TYPE=$BUILD_TYPE -T "ClangCl"
+          else
+            cmake -S "${{github.workspace}}" -B "${{github.workspace}}/build" -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+          fi
 
       - name: Build
-        run:  cmake --build "${{github.workspace}}/build" --config $BUILD_TYPE
+        run: cmake --build "${{github.workspace}}/build" --config $BUILD_TYPE
 
   test:
-    needs:   build
+    needs: build
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
       - uses: actions/checkout@v3
@@ -64,45 +64,45 @@ jobs:
           submodules: recursive
 
       - name: Configure CMake
-        run:  |
-              if [ "$RUNNER_OS" == "Windows" ]; then
-                cmake -S "${{github.workspace}}" -B "${{github.workspace}}/build" -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBUILD_ZX_TESTS=ON -T "ClangCl"
-              else
-                cmake -S "${{github.workspace}}" -B "${{github.workspace}}/build" -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBUILD_ZX_TESTS=ON
-              fi
+        run: |
+          if [ "$RUNNER_OS" == "Windows" ]; then
+            cmake -S "${{github.workspace}}" -B "${{github.workspace}}/build" -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBUILD_ZX_TESTS=ON -T "ClangCl"
+          else
+            cmake -S "${{github.workspace}}" -B "${{github.workspace}}/build" -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBUILD_ZX_TESTS=ON
+          fi
       - name: Build
-        run:  |
-              if [ "$RUNNER_OS" == "Windows" ]; then
-                cmake --build "${{github.workspace}}/build" --config $BUILD_TYPE
-              else
-                cmake --build "${{github.workspace}}/build" --config $BUILD_TYPE --target zx_test
-              fi
-      - name:              Test
+        run: |
+          if [ "$RUNNER_OS" == "Windows" ]; then
+            cmake --build "${{github.workspace}}/build" --config $BUILD_TYPE
+          else
+            cmake --build "${{github.workspace}}/build" --config $BUILD_TYPE --target zx_test
+          fi
+      - name: Test
         working-directory: ${{github.workspace}}/build/test
-        run:               |
-                           if [ "$RUNNER_OS" == "Windows" ]; then
-                             cd $BUILD_TYPE && ./zx_test.exe
-                           else
-                             ctest -C $BUILD_TYPE --output-on-failure
-                           fi
+        run: |
+          if [ "$RUNNER_OS" == "Windows" ]; then
+            cd $BUILD_TYPE && ./zx_test.exe
+          else
+            ctest -C $BUILD_TYPE --output-on-failure
+          fi
 
   coverage:
-    needs:   test
+    needs: test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
       - name: Configure CMake
-        run:  cmake -S "${{github.workspace}}" -B "${{github.workspace}}/build" -DCMAKE_BUILD_TYPE=Debug -DBUILD_ZX_TESTS=ON -DCOVERAGE=1
+        run: cmake -S "${{github.workspace}}" -B "${{github.workspace}}/build" -DCMAKE_BUILD_TYPE=Debug -DBUILD_ZX_TESTS=ON -DCOVERAGE=1
       - name: Build
-        run:  cmake --build "${{github.workspace}}/build" --config Debug --target zx_test
-      - name:              Test
+        run: cmake --build "${{github.workspace}}/build" --config Debug --target zx_test
+      - name: Test
         working-directory: ${{github.workspace}}/build/test
-        run:               ctest -C Debug --output-on-failure
+        run: ctest -C Debug --output-on-failure
       - name: Run gcov
-        run:  |
-              find . -type f -name '*.gcno' -exec gcov -p  {} +
+        run: |
+          find . -type f -name '*.gcno' -exec gcov -p  {} +
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,13 +2,13 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
   schedule:
     - cron: "15 21 * * 6"
 
 concurrency:
-  group:              ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 env:
@@ -16,7 +16,7 @@ env:
 
 jobs:
   analyze:
-    name:    Analyze
+    name: Analyze
     runs-on: ubuntu-latest
     permissions:
       security-events: write
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ "cpp" ]
+        language: ["cpp"]
 
     steps:
       - name: Checkout repository
@@ -36,16 +36,16 @@ jobs:
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2
         with:
-          languages:   ${{ matrix.language }}
+          languages: ${{ matrix.language }}
           config-file: .github/codeql-config.yml
 
-      - if:   matrix.language == 'cpp'
+      - if: matrix.language == 'cpp'
         name: Configure CMake
-        run:  cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_ZX_TESTS=ON
+        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_ZX_TESTS=ON
 
-      - if:   matrix.language == 'cpp'
+      - if: matrix.language == 'cpp'
         name: Build
-        run:  cmake --build build
+        run: cmake --build build
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v2
@@ -57,9 +57,9 @@ jobs:
         uses: advanced-security/filter-sarif@main
         with:
           patterns: |
-                    -**/extern/**
-          input:    sarif-results/${{ matrix.language }}.sarif
-          output:   sarif-results/${{ matrix.language }}.sarif
+            -**/extern/**
+          input: sarif-results/${{ matrix.language }}.sarif
+          output: sarif-results/${{ matrix.language }}.sarif
 
       - name: Upload SARIF
         uses: github/codeql-action/upload-sarif@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,67 @@
+# To run all pre-commit checks, use:
+#
+#     pre-commit run -a
+#
+# To install pre-commit hooks that run every time you commit:
+#
+#     pre-commit install
+#
+
+ci:
+  autoupdate_commit_msg: "⬆️🪝 update pre-commit hooks"
+  autofix_commit_msg: "🎨 pre-commit fixes"
+
+repos:
+  # Standard hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: "v4.4.0"
+    hooks:
+      - id: check-added-large-files
+      - id: check-case-conflict
+      - id: check-docstring-first
+      - id: check-merge-conflict
+      - id: check-symlinks
+      - id: check-toml
+      - id: check-yaml
+      - id: debug-statements
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+      - id: requirements-txt-fixer
+      - id: trailing-whitespace
+
+  # Handling unwanted unicode characters
+  - repo: https://github.com/sirosen/texthooks
+    rev: "0.4.0"
+    hooks:
+      - id: fix-ligatures
+      - id: fix-smartquotes
+
+  # Check for spelling
+  - repo: https://github.com/codespell-project/codespell
+    rev: "v2.2.2"
+    hooks:
+      - id: codespell
+        args: ["-L", "wille,linz", "--skip", "*.ipynb"]
+
+  # Clang-format the C++ part of the code base automatically
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: "v15.0.4"
+    hooks:
+      - id: clang-format
+        types_or: [c++, c, cuda]
+
+  # CMake format and lint the CMakeLists.txt files
+  - repo: https://github.com/cheshirekow/cmake-format-precommit
+    rev: v0.6.13
+    hooks:
+      - id: cmake-format
+        additional_dependencies: [pyyaml]
+      - id: cmake-lint
+        additional_dependencies: [pyyaml]
+
+  # Format configuration files with prettier
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: "v3.0.0-alpha.4"
+    hooks:
+      - id: prettier
+        types_or: [yaml, markdown, html, css, scss, javascript, json]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,10 @@
 cmake_minimum_required(VERSION 3.14...3.22)
 
-project(zx
-        LANGUAGES CXX
-        VERSION 0.1
-        DESCRIPTION "ZX - An MQT library for working with ZX-diagrams"
-        )
+project(
+  zx
+  LANGUAGES CXX
+  VERSION 0.1
+  DESCRIPTION "ZX - An MQT library for working with ZX-diagrams")
 
 # enable organization of targets into folders
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
@@ -17,16 +17,22 @@ option(BUILD_ZX_TESTS "Also build tests for ZX library")
 
 # build type settings
 set(default_build_type "Release")
-if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
-	message(STATUS "Setting build type to '${default_build_type}' as none was specified.")
-	set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE STRING "Choose the type of build." FORCE)
-	set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
-endif ()
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  message(STATUS "Setting build type to '${default_build_type}' as none was specified.")
+  set(CMAKE_BUILD_TYPE
+      "${default_build_type}"
+      CACHE STRING "Choose the type of build." FORCE)
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "MinSizeRel"
+                                               "RelWithDebInfo")
+endif()
 
 macro(check_submodule_present MODULENAME)
-	if(NOT EXISTS "${PROJECT_SOURCE_DIR}/extern/${MODULENAME}/CMakeLists.txt")
-		message(FATAL_ERROR "${MODULENAME} submodule not cloned properly. Please run `git submodule update --init --recursive` from the main project directory")
-	endif()
+  if(NOT EXISTS "${PROJECT_SOURCE_DIR}/extern/${MODULENAME}/CMakeLists.txt")
+    message(
+      FATAL_ERROR
+        "${MODULENAME} submodule not cloned properly. Please run `git submodule update --init --recursive` from the main project directory"
+    )
+  endif()
 endmacro()
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
@@ -40,13 +46,12 @@ if(NOT GMP_FOUND)
   message(NOTICE "Did not find GMP. Using Boost multiprecision library instead.")
 endif()
 
-
 # add main library code
 add_subdirectory(src)
 
 # add test code
 if(BUILD_ZX_TESTS)
-	enable_testing()
-	include(GoogleTest)
-	add_subdirectory(test)
+  enable_testing()
+  include(GoogleTest)
+  add_subdirectory(test)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,9 +16,9 @@ option(COVERAGE "Configure for coverage report generation")
 option(BUILD_ZX_TESTS "Also build tests for ZX library")
 
 # build type settings
-set(default_build_type "Release")
+set(DEFAULT_BUILD_TYPE "Release")
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
-  message(STATUS "Setting build type to '${default_build_type}' as none was specified.")
+  message(STATUS "Setting build type to '${DEFAULT_BUILD_TYPE}' as none was specified.")
   set(CMAKE_BUILD_TYPE
       "${default_build_type}"
       CACHE STRING "Choose the type of build." FORCE)
@@ -26,12 +26,14 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
                                                "RelWithDebInfo")
 endif()
 
-macro(check_submodule_present MODULENAME)
-  if(NOT EXISTS "${PROJECT_SOURCE_DIR}/extern/${MODULENAME}/CMakeLists.txt")
+# check whether the submodule ``modulename`` is correctly cloned in the ``/extern`` directory.
+macro(CHECK_SUBMODULE_PRESENT modulename)
+  if(NOT EXISTS "${PROJECT_SOURCE_DIR}/extern/${modulename}/CMakeLists.txt")
     message(
       FATAL_ERROR
-        "${MODULENAME} submodule not cloned properly. Please run `git submodule update --init --recursive` from the main project directory"
-    )
+        "${modulename} submodule not cloned properly. \
+        Please run `git submodule update --init --recursive` \
+        from the main project directory")
   endif()
 endmacro()
 

--- a/cmake/FindGMP.cmake
+++ b/cmake/FindGMP.cmake
@@ -1,4 +1,5 @@
-# File adapted from https://github.com/dune-project/dune-common/blob/master/cmake/modules/FindGMP.cmake
+# File adapted from
+# https://github.com/dune-project/dune-common/blob/master/cmake/modules/FindGMP.cmake
 
 #[=======================================================================[.rst:
 FindGMP
@@ -49,10 +50,10 @@ this module:
 
 # Add a feature summary for this package
 include(FeatureSummary)
-set_package_properties(GMP PROPERTIES
+set_package_properties(
+  GMP PROPERTIES
   DESCRIPTION "GNU multi-precision library"
-  URL "https://gmplib.org"
-)
+  URL "https://gmplib.org")
 
 # Try finding the package with pkg-config
 find_package(PkgConfig QUIET)
@@ -70,29 +71,25 @@ mark_as_advanced(GMP_INCLUDE_DIR GMP_LIB GMPXX_INCLUDE_DIR GMPXX_LIB)
 
 # Report if package was found
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(GMP
-  DEFAULT_MSG
-  GMPXX_LIB GMPXX_INCLUDE_DIR GMP_INCLUDE_DIR GMP_LIB
-)
+find_package_handle_standard_args(GMP DEFAULT_MSG GMPXX_LIB GMPXX_INCLUDE_DIR GMP_INCLUDE_DIR
+                                  GMP_LIB)
 
 # Set targets
 if(GMP_FOUND)
   # C library
   if(NOT TARGET GMP::gmp)
     add_library(GMP::gmp UNKNOWN IMPORTED)
-    set_target_properties(GMP::gmp PROPERTIES
-      IMPORTED_LOCATION ${GMP_LIB}
-      INTERFACE_INCLUDE_DIRECTORIES ${GMP_INCLUDE_DIR}
-    )
+    set_target_properties(GMP::gmp PROPERTIES IMPORTED_LOCATION ${GMP_LIB}
+                                              INTERFACE_INCLUDE_DIRECTORIES ${GMP_INCLUDE_DIR})
   endif()
 
   # C++ library, which requires a link to the C library
   if(NOT TARGET GMP::gmpxx)
     add_library(GMP::gmpxx UNKNOWN IMPORTED)
-    set_target_properties(GMP::gmpxx PROPERTIES
-      IMPORTED_LOCATION ${GMPXX_LIB}
-      INTERFACE_INCLUDE_DIRECTORIES ${GMPXX_INCLUDE_DIR}
-      INTERFACE_LINK_LIBRARIES GMP::gmp
-    )
+    set_target_properties(
+      GMP::gmpxx
+      PROPERTIES IMPORTED_LOCATION ${GMPXX_LIB}
+                 INTERFACE_INCLUDE_DIRECTORIES ${GMPXX_INCLUDE_DIR}
+                 INTERFACE_LINK_LIBRARIES GMP::gmp)
   endif()
 endif()

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import os
+
+import nox
+from nox.sessions import Session
+
+nox.options.sessions = ["lint"]
+
+PYTHON_ALL_VERSIONS = ["3.7", "3.8", "3.9", "3.10", "3.11"]
+
+if os.environ.get("CI", None):
+    nox.options.error_on_missing_interpreters = True
+
+
+@nox.session
+def lint(session: Session) -> None:
+    """
+    Lint the Python part of the codebase using pre-commit.
+    Simply execute `nox -rs lint` to run all configured hooks.
+    """
+    session.install("pre-commit")
+    session.run("pre-commit", "run", "--all-files", *session.posargs)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,22 +1,24 @@
 # main project library
-add_library(${PROJECT_NAME}
-            ${${PROJECT_NAME}_SOURCE_DIR}/include/Rational.hpp
-            ${${PROJECT_NAME}_SOURCE_DIR}/include/ZXDiagram.hpp
-            ${${PROJECT_NAME}_SOURCE_DIR}/include/Definitions.hpp
-            ${${PROJECT_NAME}_SOURCE_DIR}/include/Rules.hpp
-            ${${PROJECT_NAME}_SOURCE_DIR}/include/Simplify.hpp
-            ${${PROJECT_NAME}_SOURCE_DIR}/include/Utils.hpp
-            ${${PROJECT_NAME}_SOURCE_DIR}/include/Expression.hpp
-
-            ${CMAKE_CURRENT_SOURCE_DIR}/Rational.cpp
-            ${CMAKE_CURRENT_SOURCE_DIR}/ZXDiagram.cpp
-            ${CMAKE_CURRENT_SOURCE_DIR}/Rules.cpp
-            ${CMAKE_CURRENT_SOURCE_DIR}/Simplify.cpp
-            ${CMAKE_CURRENT_SOURCE_DIR}/Utils.cpp
-            ${CMAKE_CURRENT_SOURCE_DIR}/Expression.cpp)
+add_library(
+  ${PROJECT_NAME}
+  ${${PROJECT_NAME}_SOURCE_DIR}/include/Rational.hpp
+  ${${PROJECT_NAME}_SOURCE_DIR}/include/ZXDiagram.hpp
+  ${${PROJECT_NAME}_SOURCE_DIR}/include/Definitions.hpp
+  ${${PROJECT_NAME}_SOURCE_DIR}/include/Rules.hpp
+  ${${PROJECT_NAME}_SOURCE_DIR}/include/Simplify.hpp
+  ${${PROJECT_NAME}_SOURCE_DIR}/include/Utils.hpp
+  ${${PROJECT_NAME}_SOURCE_DIR}/include/Expression.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/Rational.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/ZXDiagram.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/Rules.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/Simplify.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/Utils.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/Expression.cpp)
 
 # set include directories
-target_include_directories(${PROJECT_NAME} PUBLIC $<BUILD_INTERFACE:${${PROJECT_NAME}_SOURCE_DIR}/include> $<BUILD_INTERFACE:${${PROJECT_NAME}_SOURCE_DIR}/extern>)
+target_include_directories(
+  ${PROJECT_NAME} PUBLIC $<BUILD_INTERFACE:${${PROJECT_NAME}_SOURCE_DIR}/include>
+                         $<BUILD_INTERFACE:${${PROJECT_NAME}_SOURCE_DIR}/extern>)
 
 # set required C++ standard and disable compiler specific extensions
 target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_17)
@@ -25,52 +27,57 @@ set_target_properties(${PROJECT_NAME} PROPERTIES CMAKE_CXX_STANDARD_REQUIRED ON 
 add_subdirectory("${PROJECT_SOURCE_DIR}/extern/boost/multiprecision" "extern/boost/multiprecision")
 add_subdirectory("${PROJECT_SOURCE_DIR}/extern/boost/config" "extern/boost/config")
 target_link_libraries(${PROJECT_NAME} PUBLIC Boost::config Boost::multiprecision)
-target_include_directories(${PROJECT_NAME} PUBLIC $<BUILD_INTERFACE:${${PROJECT_NAME}_SOURCE_DIR}/include>)
+target_include_directories(${PROJECT_NAME}
+                           PUBLIC $<BUILD_INTERFACE:${${PROJECT_NAME}_SOURCE_DIR}/include>)
 
-#   # link to GMP libraries if present
+# # link to GMP libraries if present
 if(GMP_FOUND)
   target_compile_definitions(${PROJECT_NAME} PUBLIC GMP)
   target_link_libraries(${PROJECT_NAME} PUBLIC GMP::gmp GMP::gmpxx)
 endif()
 
 # set compiler flags depending on compiler
-if (MSVC)
-	target_compile_options(${PROJECT_NAME} PUBLIC /utf-8 /W4)
-else ()
-	target_compile_options(${PROJECT_NAME} INTERFACE -Wall -Wextra -pedantic $<$<CONFIG:DEBUG>:-Og>$<$<CONFIG:RELEASE>:-fno-math-errno -ffinite-math-only -fno-trapping-math>)
-	if (BINDINGS AND NOT WIN32)
-		# adjust visibility settings for building Python bindings
-		target_compile_options(${PROJECT_NAME} PUBLIC -fvisibility=hidden)
-	endif ()
-	if (NOT DEPLOY)
-		# only include machine-specific optimizations when building for the host machine
-		target_compile_options(${PROJECT_NAME} INTERFACE -mtune=native)
-		include(CheckCXXCompilerFlag)
-		check_cxx_compiler_flag(-march=native HAS_MARCH_NATIVE)
-		if (HAS_MARCH_NATIVE)
-			target_compile_options(${PROJECT_NAME} INTERFACE -march=native)
-		endif ()
-	endif ()
-endif ()
+if(MSVC)
+  target_compile_options(${PROJECT_NAME} PUBLIC /utf-8 /W4)
+else()
+  target_compile_options(
+    ${PROJECT_NAME}
+    INTERFACE -Wall -Wextra -pedantic $<$<CONFIG:DEBUG>:-Og>$<$<CONFIG:RELEASE>:-fno-math-errno
+              -ffinite-math-only -fno-trapping-math>)
+  if(BINDINGS AND NOT WIN32)
+    # adjust visibility settings for building Python bindings
+    target_compile_options(${PROJECT_NAME} PUBLIC -fvisibility=hidden)
+  endif()
+  if(NOT DEPLOY)
+    # only include machine-specific optimizations when building for the host machine
+    target_compile_options(${PROJECT_NAME} INTERFACE -mtune=native)
+    include(CheckCXXCompilerFlag)
+    check_cxx_compiler_flag(-march=native HAS_MARCH_NATIVE)
+    if(HAS_MARCH_NATIVE)
+      target_compile_options(${PROJECT_NAME} INTERFACE -march=native)
+    endif()
+  endif()
+endif()
 
 # enable interprocedural optimization if it is supported
 include(CheckIPOSupported)
 check_ipo_supported(RESULT ipo_supported)
-if (ipo_supported)
-	set_target_properties(${TARGETNAME} PROPERTIES INTERPROCEDURAL_OPTIMIZATION TRUE)
-endif ()
+if(ipo_supported)
+  set_target_properties(${TARGETNAME} PROPERTIES INTERPROCEDURAL_OPTIMIZATION TRUE)
+endif()
 
-if (GENERATE_POSITION_INDEPENDENT_CODE OR BINDINGS)
-	include(CheckPIESupported)
-	check_pie_supported()
-	set_target_properties(${PROJECT_NAME} PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
-endif ()
+if(GENERATE_POSITION_INDEPENDENT_CODE OR BINDINGS)
+  include(CheckPIESupported)
+  check_pie_supported()
+  set_target_properties(${PROJECT_NAME} PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
+endif()
 
-# add coverage compiler and linker flag to the library and all targets that link against it, if COVERAGE is set
-if (COVERAGE)
-	target_compile_options(${PROJECT_NAME} PUBLIC --coverage)
-	target_link_libraries(${PROJECT_NAME} PUBLIC --coverage)
-endif ()
+# add coverage compiler and linker flag to the library and all targets that link against it, if
+# COVERAGE is set
+if(COVERAGE)
+  target_compile_options(${PROJECT_NAME} PUBLIC --coverage)
+  target_link_libraries(${PROJECT_NAME} PUBLIC --coverage)
+endif()
 
 # add MQT alias
 add_library(MQT::${PROJECT_NAME} ALIAS ${PROJECT_NAME})

--- a/src/Rules.cpp
+++ b/src/Rules.cpp
@@ -323,7 +323,7 @@ namespace zx {
 
             for (const auto& [nn, nnEtype]:
                  diag.incidentEdges(id1.value())) { // Todo: maybe problem with parallel edge?
-                                                    // There shouldnt be any
+                                                    // There shouldn't be any
                 if (nnEtype != zx::EdgeType::Hadamard || diag.isDeleted(nn)) {
                     // not a phase gadget
                     foundGadget = false;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 if(NOT TARGET gtest OR NOT TARGET gmock)
   # Prevent overriding the parent project's compiler/linker settings on Windows
-  set(gtest_force_shared_crt
+  set(gtest_force_shared_crt # cmake-lint: disable=C0103
       ON
       CACHE BOOL "" FORCE)
   add_subdirectory("${PROJECT_SOURCE_DIR}/extern/googletest" "extern/googletest" EXCLUDE_FROM_ALL)
@@ -22,27 +22,28 @@ if(NOT TARGET gtest OR NOT TARGET gmock)
   endif()
 endif()
 
-macro(package_add_test TESTNAME)
-  # create an exectuable in which the tests will be stored
-  add_executable(${TESTNAME} ${ARGN})
-  # link the Google test infrastructure and a default main fuction to the test executable.
-  target_link_libraries(${TESTNAME} PRIVATE ${PROJECT_NAME} gmock gtest_main)
+# macro to add a test executable for one of the project libraries
+macro(PACKAGE_ADD_TEST testname)
+  # create an executable in which the tests will be stored
+  add_executable(${testname} ${ARGN})
+  # link the Google test infrastructure and a default main function to the test executable.
+  target_link_libraries(${testname} PRIVATE ${PROJECT_NAME} gmock gtest_main)
   # discover tests
   gtest_discover_tests(
-    ${TESTNAME}
+    ${testname}
     WORKING_DIRECTORY ${PROJECT_DIR}
     PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY "${PROJECT_DIR}")
   set_target_properties(
-    ${TESTNAME}
+    ${testname}
     PROPERTIES FOLDER tests
                CMAKE_CXX_STANDARD_REQUIRED ON
                CXX_EXTENSIONS OFF)
   add_custom_command(
-    TARGET ${TESTNAME}
+    TARGET ${testname}
     POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E create_symlink $<TARGET_FILE_DIR:${TESTNAME}>/${TESTNAME}
-            ${CMAKE_BINARY_DIR}/${TESTNAME}
-    COMMENT "Creating symlinks for ${TESTNAME}"
+    COMMAND ${CMAKE_COMMAND} -E create_symlink $<TARGET_FILE_DIR:${testname}>/${testname}
+            ${CMAKE_BINARY_DIR}/${testname}
+    COMMENT "Creating symlinks for ${testname}"
     VERBATIM)
 endmacro()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,39 +1,53 @@
-if (NOT TARGET gtest OR NOT TARGET gmock)
-	# Prevent overriding the parent project's compiler/linker settings on Windows
-	set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-	add_subdirectory("${PROJECT_SOURCE_DIR}/extern/googletest" "extern/googletest" EXCLUDE_FROM_ALL)
-	mark_as_advanced(
-			BUILD_GMOCK BUILD_GTEST BUILD_SHARED_LIBS
-			gmock_build_tests gtest_build_samples gtest_build_tests
-			gtest_disable_pthreads gtest_force_shared_crt gtest_hide_internal_symbols
-	)
-	set_target_properties(gtest gtest_main gmock gmock_main PROPERTIES FOLDER extern)
-	if (BINDINGS AND NOT WIN32)
-		# adjust visibility settings for building Python bindings
-		target_compile_options(gtest PUBLIC -fvisibility=hidden)
-		target_compile_options(gmock PUBLIC -fvisibility=hidden)
-	endif ()
-endif ()
+if(NOT TARGET gtest OR NOT TARGET gmock)
+  # Prevent overriding the parent project's compiler/linker settings on Windows
+  set(gtest_force_shared_crt
+      ON
+      CACHE BOOL "" FORCE)
+  add_subdirectory("${PROJECT_SOURCE_DIR}/extern/googletest" "extern/googletest" EXCLUDE_FROM_ALL)
+  mark_as_advanced(
+    BUILD_GMOCK
+    BUILD_GTEST
+    BUILD_SHARED_LIBS
+    gmock_build_tests
+    gtest_build_samples
+    gtest_build_tests
+    gtest_disable_pthreads
+    gtest_force_shared_crt
+    gtest_hide_internal_symbols)
+  set_target_properties(gtest gtest_main gmock gmock_main PROPERTIES FOLDER extern)
+  if(BINDINGS AND NOT WIN32)
+    # adjust visibility settings for building Python bindings
+    target_compile_options(gtest PUBLIC -fvisibility=hidden)
+    target_compile_options(gmock PUBLIC -fvisibility=hidden)
+  endif()
+endif()
 
 macro(package_add_test TESTNAME)
-	# create an exectuable in which the tests will be stored
-	add_executable(${TESTNAME} ${ARGN})
-	# link the Google test infrastructure and a default main fuction to the test executable.
-	target_link_libraries(${TESTNAME} PRIVATE ${PROJECT_NAME} gmock gtest_main)
-	# discover tests
-	gtest_discover_tests(${TESTNAME} WORKING_DIRECTORY ${PROJECT_DIR} PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY "${PROJECT_DIR}")
-	set_target_properties(${TESTNAME} PROPERTIES FOLDER tests CMAKE_CXX_STANDARD_REQUIRED ON CXX_EXTENSIONS OFF)
-        add_custom_command(TARGET ${TESTNAME}
-                           POST_BUILD
-                           COMMAND ${CMAKE_COMMAND} -E create_symlink $<TARGET_FILE_DIR:${TESTNAME}>/${TESTNAME} ${CMAKE_BINARY_DIR}/${TESTNAME}
-                           COMMENT "Creating symlinks for ${TESTNAME}"
-                           VERBATIM)
+  # create an exectuable in which the tests will be stored
+  add_executable(${TESTNAME} ${ARGN})
+  # link the Google test infrastructure and a default main fuction to the test executable.
+  target_link_libraries(${TESTNAME} PRIVATE ${PROJECT_NAME} gmock gtest_main)
+  # discover tests
+  gtest_discover_tests(
+    ${TESTNAME}
+    WORKING_DIRECTORY ${PROJECT_DIR}
+    PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY "${PROJECT_DIR}")
+  set_target_properties(
+    ${TESTNAME}
+    PROPERTIES FOLDER tests
+               CMAKE_CXX_STANDARD_REQUIRED ON
+               CXX_EXTENSIONS OFF)
+  add_custom_command(
+    TARGET ${TESTNAME}
+    POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E create_symlink $<TARGET_FILE_DIR:${TESTNAME}>/${TESTNAME}
+            ${CMAKE_BINARY_DIR}/${TESTNAME}
+    COMMENT "Creating symlinks for ${TESTNAME}"
+    VERBATIM)
 endmacro()
 
 # add unit tests
-package_add_test(${PROJECT_NAME}_test
-  ${CMAKE_CURRENT_SOURCE_DIR}/test_zx.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/test_rational.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/test_expression.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/test_simplify.cpp
-)
+package_add_test(
+  ${PROJECT_NAME}_test ${CMAKE_CURRENT_SOURCE_DIR}/test_zx.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/test_rational.cpp ${CMAKE_CURRENT_SOURCE_DIR}/test_expression.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/test_simplify.cpp)


### PR DESCRIPTION
This PR introduces a minimal pre-commit configuration and a corresponding `nox` session setup to conveniently run pre-commit. I'll enable the pre-commit.ci bot as well in combination with this PR. This should avoid lots of inconsistencies that can arise as the code base grows in the future.

There are multiple ways to run the pre-commit checks
```console
nox -rs lint
```
Or directly
```console
pre-commit run -a
```
Or automatically with every commit by installing git hooks
```console
pre-commit install
```

Only if none of the above have been set up or executed, the CI bot will automatically apply fixes to PRs.

> **Note**
> `pre-commit` and `nox` can be conveniently installed via `pipx install ...` (or via `brew` on macOS).
> `pipx` can be obtained via `pip install pipx` (or via `brew` on macOS)