### PR TITLE
♻️ Refactor CMake Configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
-cmake_minimum_required(VERSION 3.14...3.22)
+# set required cmake version
+cmake_minimum_required(VERSION 3.19)
 
 project(
   zx

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ If you have any questions, feel free to contact us via [quantum.cda@xcit.tum.de]
 
 ## System Requirements and Building
 
-The implementation is compatible with any C++17 compiler and a minimum CMake version of 3.14.
+The implementation is compatible with any C++17 compiler and a minimum CMake version of 3.19.
 
 To get the most out of this library it is recommended to have the GMP library installed.
 

--- a/include/Definitions.hpp
+++ b/include/Definitions.hpp
@@ -3,6 +3,7 @@
 #include "Expression.hpp"
 #include "Rational.hpp"
 
+#include <cstdint>
 #include <stdexcept>
 #include <string>
 
@@ -10,15 +11,15 @@ namespace zx {
 enum class EdgeType { Simple, Hadamard };
 enum class VertexType { Boundary, Z, X };
 using Vertex = std::size_t;
-using Col    = int;
-using Qubit  = int;
+using Col    = std::int32_t;
+using Qubit  = std::int32_t;
 using fp     = double;
 
-constexpr double        MAX_DENOM           = 1e9; // TODO: maybe too high
-constexpr double        PARAMETER_TOLERANCE = 1e-13;
-constexpr double        TOLERANCE           = 1e-13;
-static constexpr double PI =
-    3.141592653589793238462643383279502884197169399375105820974L;
+constexpr fp          MAX_DENOM           = 1e9; // TODO: maybe too high
+constexpr fp          PARAMETER_TOLERANCE = 1e-13;
+constexpr fp          TOLERANCE           = 1e-13;
+static constexpr auto PI                  = static_cast<fp>(
+    3.141592653589793238462643383279502884197169399375105820974L);
 
 using PiExpression = sym::Expression<double, PiRational>;
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,34 +1,44 @@
 # main project library
 add_library(
   ${PROJECT_NAME}
-  ${${PROJECT_NAME}_SOURCE_DIR}/include/Rational.hpp
-  ${${PROJECT_NAME}_SOURCE_DIR}/include/ZXDiagram.hpp
-  ${${PROJECT_NAME}_SOURCE_DIR}/include/Definitions.hpp
-  ${${PROJECT_NAME}_SOURCE_DIR}/include/Rules.hpp
-  ${${PROJECT_NAME}_SOURCE_DIR}/include/Simplify.hpp
-  ${${PROJECT_NAME}_SOURCE_DIR}/include/Utils.hpp
-  ${${PROJECT_NAME}_SOURCE_DIR}/include/Expression.hpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/Rational.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/ZXDiagram.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/Rules.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/Simplify.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/Utils.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/Expression.cpp)
+  ${PROJECT_SOURCE_DIR}/include/Rational.hpp
+  ${PROJECT_SOURCE_DIR}/include/ZXDiagram.hpp
+  ${PROJECT_SOURCE_DIR}/include/Definitions.hpp
+  ${PROJECT_SOURCE_DIR}/include/Rules.hpp
+  ${PROJECT_SOURCE_DIR}/include/Simplify.hpp
+  ${PROJECT_SOURCE_DIR}/include/Utils.hpp
+  ${PROJECT_SOURCE_DIR}/include/Expression.hpp
+  Rational.cpp
+  ZXDiagram.cpp
+  Rules.cpp
+  Simplify.cpp
+  Utils.cpp
+  Expression.cpp)
 
 # set include directories
-target_include_directories(
-  ${PROJECT_NAME} PUBLIC $<BUILD_INTERFACE:${${PROJECT_NAME}_SOURCE_DIR}/include>
-                         $<BUILD_INTERFACE:${${PROJECT_NAME}_SOURCE_DIR}/extern>)
+target_include_directories(${PROJECT_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/include
+                                                  ${PROJECT_BINARY_DIR}/include)
 
 # set required C++ standard and disable compiler specific extensions
 target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_17)
 set_target_properties(${PROJECT_NAME} PROPERTIES CMAKE_CXX_STANDARD_REQUIRED ON CXX_EXTENSIONS OFF)
 
-add_subdirectory("${PROJECT_SOURCE_DIR}/extern/boost/multiprecision" "extern/boost/multiprecision")
-add_subdirectory("${PROJECT_SOURCE_DIR}/extern/boost/config" "extern/boost/config")
-target_link_libraries(${PROJECT_NAME} PUBLIC Boost::config Boost::multiprecision)
-target_include_directories(${PROJECT_NAME}
-                           PUBLIC $<BUILD_INTERFACE:${${PROJECT_NAME}_SOURCE_DIR}/include>)
+add_subdirectory("${PROJECT_SOURCE_DIR}/extern/boost/config" "extern/boost/config" EXCLUDE_FROM_ALL)
+target_link_libraries(${PROJECT_NAME} PUBLIC Boost::config)
+
+add_subdirectory("${PROJECT_SOURCE_DIR}/extern/boost/multiprecision" "extern/boost/multiprecision"
+                 EXCLUDE_FROM_ALL)
+target_link_libraries(${PROJECT_NAME} PUBLIC Boost::multiprecision)
+# the following sets the SYSTEM flag for the include dirs of the boost libs to suppress warnings
+# cmake-lint: disable=C0307
+set_target_properties(
+  boost_config PROPERTIES INTERFACE_SYSTEM_INCLUDE_DIRECTORIES
+                          $<TARGET_PROPERTY:boost_config,INTERFACE_INCLUDE_DIRECTORIES>)
+# cmake-lint: disable=C0307
+set_target_properties(
+  boost_multiprecision
+  PROPERTIES INTERFACE_SYSTEM_INCLUDE_DIRECTORIES
+             $<TARGET_PROPERTY:boost_multiprecision,INTERFACE_INCLUDE_DIRECTORIES>)
 
 # # link to GMP libraries if present
 if(GMP_FOUND)
@@ -42,19 +52,24 @@ if(MSVC)
 else()
   target_compile_options(
     ${PROJECT_NAME}
-    INTERFACE -Wall -Wextra -pedantic $<$<CONFIG:DEBUG>:-Og>$<$<CONFIG:RELEASE>:-fno-math-errno
-              -ffinite-math-only -fno-trapping-math>)
+    PUBLIC -Wall
+           -Wextra
+           -pedantic
+           -g
+           $<$<CONFIG:RELEASE>:-fno-math-errno
+           -ffinite-math-only
+           -fno-trapping-math>)
   if(BINDINGS AND NOT WIN32)
     # adjust visibility settings for building Python bindings
     target_compile_options(${PROJECT_NAME} PUBLIC -fvisibility=hidden)
   endif()
   if(NOT DEPLOY)
     # only include machine-specific optimizations when building for the host machine
-    target_compile_options(${PROJECT_NAME} INTERFACE -mtune=native)
+    target_compile_options(${PROJECT_NAME} PUBLIC -mtune=native)
     include(CheckCXXCompilerFlag)
     check_cxx_compiler_flag(-march=native HAS_MARCH_NATIVE)
     if(HAS_MARCH_NATIVE)
-      target_compile_options(${PROJECT_NAME} INTERFACE -march=native)
+      target_compile_options(${PROJECT_NAME} PUBLIC -march=native)
     endif()
   endif()
 endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,51 +4,23 @@ if(NOT TARGET gtest OR NOT TARGET gmock)
       ON
       CACHE BOOL "" FORCE)
   add_subdirectory("${PROJECT_SOURCE_DIR}/extern/googletest" "extern/googletest" EXCLUDE_FROM_ALL)
-  mark_as_advanced(
-    BUILD_GMOCK
-    BUILD_GTEST
-    BUILD_SHARED_LIBS
-    gmock_build_tests
-    gtest_build_samples
-    gtest_build_tests
-    gtest_disable_pthreads
-    gtest_force_shared_crt
-    gtest_hide_internal_symbols)
   set_target_properties(gtest gtest_main gmock gmock_main PROPERTIES FOLDER extern)
-  if(BINDINGS AND NOT WIN32)
-    # adjust visibility settings for building Python bindings
-    target_compile_options(gtest PUBLIC -fvisibility=hidden)
-    target_compile_options(gmock PUBLIC -fvisibility=hidden)
-  endif()
 endif()
 
 # macro to add a test executable for one of the project libraries
-macro(PACKAGE_ADD_TEST testname)
+macro(PACKAGE_ADD_TEST testname linklibs)
   # create an executable in which the tests will be stored
   add_executable(${testname} ${ARGN})
   # link the Google test infrastructure and a default main function to the test executable.
-  target_link_libraries(${testname} PRIVATE ${PROJECT_NAME} gmock gtest_main)
+  target_link_libraries(${testname} PRIVATE ${linklibs} gmock gtest_main)
   # discover tests
   gtest_discover_tests(
     ${testname}
-    WORKING_DIRECTORY ${PROJECT_DIR}
-    PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY "${PROJECT_DIR}")
-  set_target_properties(
-    ${testname}
-    PROPERTIES FOLDER tests
-               CMAKE_CXX_STANDARD_REQUIRED ON
-               CXX_EXTENSIONS OFF)
-  add_custom_command(
-    TARGET ${testname}
-    POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E create_symlink $<TARGET_FILE_DIR:${testname}>/${testname}
-            ${CMAKE_BINARY_DIR}/${testname}
-    COMMENT "Creating symlinks for ${testname}"
-    VERBATIM)
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
+  set_target_properties(${testname} PROPERTIES FOLDER tests)
 endmacro()
 
 # add unit tests
-package_add_test(
-  ${PROJECT_NAME}_test ${CMAKE_CURRENT_SOURCE_DIR}/test_zx.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/test_rational.cpp ${CMAKE_CURRENT_SOURCE_DIR}/test_expression.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/test_simplify.cpp)
+package_add_test(${PROJECT_NAME}_test ${PROJECT_NAME} test_zx.cpp test_rational.cpp
+                 test_expression.cpp test_simplify.cpp)


### PR DESCRIPTION
This PR refactors the overall CMake configuration (builds on https://github.com/cda-tum/dd_package/pull/125) and brings the ZX repository one step closer to the `mqt-core` package.